### PR TITLE
Update CloudUtils.java to use getServiceName instead of getService().getName()

### DIFF
--- a/src/main/java/de/bypixeltv/redivelocity/utils/CloudUtils.java
+++ b/src/main/java/de/bypixeltv/redivelocity/utils/CloudUtils.java
@@ -29,7 +29,7 @@ public class CloudUtils {
             final ServiceInfoHolder serviceInfoHolder = InjectionLayer.ext().instance(ServiceInfoHolder.class);
             return serviceInfoHolder.serviceInfo().name();
         } else if (cloud.equalsIgnoreCase("vulpescloud")) {
-            return Wrapper.instance.getService().getName();
+            return Wrapper.instance.getServiceName();
         } else {
             return null;
         }


### PR DESCRIPTION
This PR updates the used API from VulpesCloud to use `Wrapper.instance.getServiceName()` instead of `Wrapper.instance.getService().getName()` this is due to API Changes in VulpesCloud